### PR TITLE
Add CLI support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+'use strict';
+var pkg = require('./package.json');
+var parser = require('./index');
+var input = process.argv[2];
+
+function help() {
+  console.log(pkg.description);
+  console.log('');
+  console.log('Usage');
+  console.log('  $ google-spreadsheets-key-parser <url>');
+}
+
+if (!input || process.argv.indexOf('-h') !== -1 || process.argv.indexOf('--help') !== -1) {
+  help();
+  return;
+}
+
+if (process.argv.indexOf('-v') !== -1 || process.argv.indexOf('--version') !== -1) {
+  console.log(pkg.version);
+  return;
+}
+
+console.log(parser(input));

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "node test.js"
   },
+  "bin": {
+    "google-spreadsheets-key-parser": "cli.js"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -13,3 +13,20 @@ var parsed = parser('https://docs.google.com/spreadsheets/d/1jHY4wO4b0kuX4rVnJgZ
 ```
 
 works for new and old sheets. `isNewSheets` will be true if it's new sheets, false if it's old sheets
+
+## CLI
+
+You can also use it as a CLI app by installing it globally:
+
+```bash
+$ npm install --global google-spreadsheets-key-parser
+```
+
+#### Usage
+
+```bash
+$ google-spreadsheets-key-parser --help
+
+Usage
+  $ google-spreadsheets-key-parser <url>
+```


### PR DESCRIPTION
Adjusted simple CLI code from @sindresorhus, see for example [sindresorhus/latest-version](https://github.com/sindresorhus/latest-version).

Just returns raw JSON to the CLI:

``` sh
$ google-spreadsheets-key-parser https://docs.google.com/spreadsheets/d/1jHY4wO4b0kuX4rVnJgZGwfQUzoxado52k1hzxdUY-AM/edit?pli=1#gid=0
{ key: '1jHY4wO4b0kuX4rVnJgZGwfQUzoxado52k1hzxdUY-AM',
  isNewSheets: true }
```
